### PR TITLE
Rename TitanAgents → TitanEchoAssist across entire codebase

### DIFF
--- a/Modules/Accountings/AI/Channels/channel.manifest.json
+++ b/Modules/Accountings/AI/Channels/channel.manifest.json
@@ -12,7 +12,7 @@
   ],
   "routing": {
     "system_ai": "TitanZero",
-    "module_ai": "TitanAgents",
+    "module_ai": "TitanEchoAssist",
     "handoff_rules": [
       "system_intents_to_zero",
       "module_intents_to_agent",

--- a/Modules/Accountings/AI/Control/README.md
+++ b/Modules/Accountings/AI/Control/README.md
@@ -5,14 +5,14 @@ This module is controllable through Filament chat, PWA chat, connected channels,
 ## Runtime ownership
 
 - **TitanZero** is the system AI supervisor: routing, governance, configuration, diagnostics, cross-module orchestration.
-- **TitanAgents** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
+- **TitanEchoAssist** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
 - **TitanCore** owns providers, embeddings, retrieval primitives, prompt registry, usage tracking, policies, and audit infrastructure.
 
 ## Command lifecycle
 
 1. User speaks or chats from Filament, PWA, or an external channel.
 2. TitanZero classifies whether the request is system-level or module-level.
-3. Module-level requests route to this module's TitanAgents agent.
+3. Module-level requests route to this module's TitanEchoAssist agent.
 4. The agent retrieves from `Knowledge/`, reads the module state, and selects an action.
 5. Write/destructive actions require confirmation unless explicitly marked safe.
 6. TitanCore logs usage, policy decisions, citations, and tool execution.

--- a/Modules/Accountings/Agents/ModuleAgent/agent.manifest.json
+++ b/Modules/Accountings/Agents/ModuleAgent/agent.manifest.json
@@ -3,7 +3,7 @@
   "agent": "titanzero.money",
   "display_name": "TitanZero Money",
   "module": "money-manager",
-  "owner": "TitanAgents",
+  "owner": "TitanEchoAssist",
   "runtime": "TitanCore.ProviderRouter",
   "system_supervisor": "TitanZero",
   "answer_mode": "grounded_with_citations",

--- a/Modules/Accountings/Docs/AI_CONTROL_AND_CHANNELS.md
+++ b/Modules/Accountings/Docs/AI_CONTROL_AND_CHANNELS.md
@@ -20,4 +20,4 @@ Read actions can execute after policy checks. Draft actions do not save until co
 
 ## Routing model
 
-TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanAgents handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.
+TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanEchoAssist handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.

--- a/Modules/Accountings/Filament/PageManifest/module-page.json
+++ b/Modules/Accountings/Filament/PageManifest/module-page.json
@@ -23,7 +23,7 @@
   },
   "chat": {
     "agent": "titanzero.money",
-    "provider": "TitanAgents",
+    "provider": "TitanEchoAssist",
     "system_supervisor": "TitanZero",
     "supports": [
       "text",

--- a/Modules/Accountings/module.json
+++ b/Modules/Accountings/module.json
@@ -12,7 +12,7 @@
   ],
   "requires": [
     "TitanCore",
-    "TitanAgents"
+    "TitanEchoAssist"
   ],
   "optional_requires": [
     "EInvoice",

--- a/Modules/BookingModule/ACCEPTANCE.md
+++ b/Modules/BookingModule/ACCEPTANCE.md
@@ -7,4 +7,4 @@
 - All writes flow through Actions or existing Services.
 - Scheduled reminders are company-scoped and deduplicated.
 - Booking lifecycle events are logged and can send queued mail.
-- AI manifests and ModuleAgent policy are present for TitanCore/TitanAgents discovery.
+- AI manifests and ModuleAgent policy are present for TitanCore/TitanEchoAssist discovery.

--- a/Modules/BookingModule/AI/Control/README.md
+++ b/Modules/BookingModule/AI/Control/README.md
@@ -1,3 +1,3 @@
 # AI Control
 
-Zero remains user-facing. BookingModule agent manifests are routed internally by TitanAgents.
+Zero remains user-facing. BookingModule agent manifests are routed internally by TitanEchoAssist.

--- a/Modules/BookingModule/AI/README.md
+++ b/Modules/BookingModule/AI/README.md
@@ -1,3 +1,3 @@
 # BookingModule AI Surface
 
-Metadata-only AI surface for TitanCore/TitanAgents. Runtime AI services, vector stores, providers, billing and governance live outside this module.
+Metadata-only AI surface for TitanCore/TitanEchoAssist. Runtime AI services, vector stores, providers, billing and governance live outside this module.

--- a/Modules/BookingModule/Agents/ModuleAgent/policies/agent-policy.md
+++ b/Modules/BookingModule/Agents/ModuleAgent/policies/agent-policy.md
@@ -1,6 +1,6 @@
 # BookingModule Agent Policy
 
-The BookingModuleAgent is internal-only and routed by TitanAgents/TitanZero.
+The BookingModuleAgent is internal-only and routed by TitanEchoAssist/TitanZero.
 
 - Never cross company boundaries.
 - Reads require BookingModule policy or permission.

--- a/Modules/BookingModule/Agents/ModuleAgent/prompts/system.md
+++ b/Modules/BookingModule/Agents/ModuleAgent/prompts/system.md
@@ -1,1 +1,1 @@
-You are BookingModuleAgent, an internal TitanAgents specialist for booking, schedule and dispatch workflows. Answer from module records and module Knowledge. Route writes through approved Actions only.
+You are BookingModuleAgent, an internal TitanEchoAssist specialist for booking, schedule and dispatch workflows. Answer from module records and module Knowledge. Route writes through approved Actions only.

--- a/Modules/BookingModule/Agents/ModuleAgent/training/dataset-manifest.json
+++ b/Modules/BookingModule/Agents/ModuleAgent/training/dataset-manifest.json
@@ -1,1 +1,1 @@
-{"module":"bookingmodule","datasets":[],"notes":"Training data is managed by TitanAgents; module only declares ownership metadata."}
+{"module":"bookingmodule","datasets":[],"notes":"Training data is managed by TitanEchoAssist; module only declares ownership metadata."}

--- a/Modules/BookingModule/Agents/README.md
+++ b/Modules/BookingModule/Agents/README.md
@@ -1,3 +1,3 @@
 # BookingModule Agents
 
-Module agents are internal agents owned by TitanAgents. Users talk to Zero; Zero may route to this module agent invisibly.
+Module agents are internal agents owned by TitanEchoAssist. Users talk to Zero; Zero may route to this module agent invisibly.

--- a/Modules/BookingModule/Knowledge/README.md
+++ b/Modules/BookingModule/Knowledge/README.md
@@ -1,3 +1,3 @@
 # BookingModule Knowledge
 
-Module-local guides, SOPs, FAQs, compliance notes, pricing examples and checklists for retrieval by TitanCore/TitanAgents.
+Module-local guides, SOPs, FAQs, compliance notes, pricing examples and checklists for retrieval by TitanCore/TitanEchoAssist.

--- a/Modules/EInvoice/AI/Channels/channel.manifest.json
+++ b/Modules/EInvoice/AI/Channels/channel.manifest.json
@@ -12,7 +12,7 @@
   ],
   "routing": {
     "system_ai": "TitanZero",
-    "module_ai": "TitanAgents",
+    "module_ai": "TitanEchoAssist",
     "handoff_rules": [
       "system_intents_to_zero",
       "module_intents_to_agent",

--- a/Modules/EInvoice/AI/Control/README.md
+++ b/Modules/EInvoice/AI/Control/README.md
@@ -5,14 +5,14 @@ This module is controllable through Filament chat, PWA chat, connected channels,
 ## Runtime ownership
 
 - **TitanZero** is the system AI supervisor: routing, governance, configuration, diagnostics, cross-module orchestration.
-- **TitanAgents** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
+- **TitanEchoAssist** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
 - **TitanCore** owns providers, embeddings, retrieval primitives, prompt registry, usage tracking, policies, and audit infrastructure.
 
 ## Command lifecycle
 
 1. User speaks or chats from Filament, PWA, or an external channel.
 2. TitanZero classifies whether the request is system-level or module-level.
-3. Module-level requests route to this module's TitanAgents agent.
+3. Module-level requests route to this module's TitanEchoAssist agent.
 4. The agent retrieves from `Knowledge/`, reads the module state, and selects an action.
 5. Write/destructive actions require confirmation unless explicitly marked safe.
 6. TitanCore logs usage, policy decisions, citations, and tool execution.

--- a/Modules/EInvoice/Agents/ModuleAgent/agent.manifest.json
+++ b/Modules/EInvoice/Agents/ModuleAgent/agent.manifest.json
@@ -3,7 +3,7 @@
   "agent": "titanzero.money",
   "display_name": "TitanZero Money",
   "module": "money-manager",
-  "owner": "TitanAgents",
+  "owner": "TitanEchoAssist",
   "runtime": "TitanCore.ProviderRouter",
   "system_supervisor": "TitanZero",
   "answer_mode": "grounded_with_citations",

--- a/Modules/EInvoice/Docs/AI_CONTROL_AND_CHANNELS.md
+++ b/Modules/EInvoice/Docs/AI_CONTROL_AND_CHANNELS.md
@@ -20,4 +20,4 @@ Read actions can execute after policy checks. Draft actions do not save until co
 
 ## Routing model
 
-TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanAgents handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.
+TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanEchoAssist handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.

--- a/Modules/EInvoice/Filament/PageManifest/module-page.json
+++ b/Modules/EInvoice/Filament/PageManifest/module-page.json
@@ -23,7 +23,7 @@
   },
   "chat": {
     "agent": "titanzero.money",
-    "provider": "TitanAgents",
+    "provider": "TitanEchoAssist",
     "system_supervisor": "TitanZero",
     "supports": [
       "text",

--- a/Modules/EInvoice/module.json
+++ b/Modules/EInvoice/module.json
@@ -12,7 +12,7 @@
   ],
   "requires": [
     "TitanCore",
-    "TitanAgents"
+    "TitanEchoAssist"
   ],
   "optional_requires": [
     "Accountings",

--- a/Modules/ExampleModule/AI/Control/README.md
+++ b/Modules/ExampleModule/AI/Control/README.md
@@ -5,14 +5,14 @@ This module is controllable through Filament chat, PWA chat, connected channels,
 ## Runtime ownership
 
 - **TitanZero** is the system AI supervisor: routing, governance, configuration, diagnostics, cross-module orchestration.
-- **TitanAgents** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
+- **TitanEchoAssist** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
 - **TitanCore** owns providers, embeddings, retrieval primitives, prompt registry, usage tracking, policies, and audit infrastructure.
 
 ## Command lifecycle
 
 1. User speaks or chats from Filament, PWA, or an external channel.
 2. TitanZero classifies whether the request is system-level or module-level.
-3. Module-level requests route to this module's TitanAgents agent.
+3. Module-level requests route to this module's TitanEchoAssist agent.
 4. The agent retrieves from `Knowledge/`, reads the module state, and selects an action.
 5. Write/destructive actions require confirmation unless explicitly marked safe.
 6. TitanCore logs usage, policy decisions, citations, and tool execution.

--- a/Modules/ExampleModule/AI/README.md
+++ b/Modules/ExampleModule/AI/README.md
@@ -1,3 +1,3 @@
 # AI Integration Layer
 
-Contracts that connect this module to TitanCore, TitanZero and TitanAgents without duplicating AI infrastructure.
+Contracts that connect this module to TitanCore, TitanZero and TitanEchoAssist without duplicating AI infrastructure.

--- a/Modules/ExampleModule/Agents/ModuleAgent/agent.manifest.json
+++ b/Modules/ExampleModule/Agents/ModuleAgent/agent.manifest.json
@@ -3,7 +3,7 @@
   "agent": "example-module.agent",
   "display_name": "Example Module Agent",
   "module": "example-module",
-  "owner": "TitanAgents",
+  "owner": "TitanEchoAssist",
   "runtime": "TitanCore.ProviderRouter",
   "system_supervisor": "TitanZero",
   "answer_mode": "grounded_with_citations",

--- a/Modules/ExampleModule/Agents/ModuleAgent/policies/agent-policy.md
+++ b/Modules/ExampleModule/Agents/ModuleAgent/policies/agent-policy.md
@@ -1,3 +1,3 @@
 # Module Agent Policy
 
-The agent is trained/bound by TitanAgents, consumes TitanCore for AI runtime, and is supervised by TitanZero. It may only access current-company data.
+The agent is trained/bound by TitanEchoAssist, consumes TitanCore for AI runtime, and is supervised by TitanZero. It may only access current-company data.

--- a/Modules/ExampleModule/Config/module.php
+++ b/Modules/ExampleModule/Config/module.php
@@ -17,7 +17,7 @@ return [
     'ai' => [
         'core_runtime' => 'TitanCore',
         'system_supervisor' => 'TitanZero',
-        'agent_owner' => 'TitanAgents',
+        'agent_owner' => 'TitanEchoAssist',
         'agent_manifest' => base_path('Modules/ExampleModule/Agents/ModuleAgent/agent.manifest.json'),
         'indexing_manifest' => base_path('Modules/ExampleModule/AI/Indexing/indexing.manifest.json'),
     ],

--- a/Modules/ExampleModule/Docs/AI_CONTROL_AND_CHANNELS.md
+++ b/Modules/ExampleModule/Docs/AI_CONTROL_AND_CHANNELS.md
@@ -20,4 +20,4 @@ Read actions can execute after policy checks. Draft actions do not save until co
 
 ## Routing model
 
-TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanAgents handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.
+TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanEchoAssist handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.

--- a/Modules/ExampleModule/Docs/AI_NATIVE_MODULE_GUIDE.md
+++ b/Modules/ExampleModule/Docs/AI_NATIVE_MODULE_GUIDE.md
@@ -6,7 +6,7 @@ Each Titan module can ship domain knowledge and one or more module agents.
 |---|---|
 | TitanCore | provider routing, embeddings, vector search, memory, usage, policy middleware |
 | TitanZero | system AI, configuration, governance, diagnostics, escalation |
-| TitanAgents | module agent builder, training/binding, evals, deployment |
+| TitanEchoAssist | module agent builder, training/binding, evals, deployment |
 | Module | domain files, workflows, actions, tools, permissions |
 
-Lifecycle: add files to Knowledge, approve them in dataset-manifest, TitanCore indexes them, TitanAgents binds the agent, TitanZero monitors and configures.
+Lifecycle: add files to Knowledge, approve them in dataset-manifest, TitanCore indexes them, TitanEchoAssist binds the agent, TitanZero monitors and configures.

--- a/Modules/ExampleModule/Filament/PageManifest/module-page.json
+++ b/Modules/ExampleModule/Filament/PageManifest/module-page.json
@@ -23,7 +23,7 @@
   },
   "chat": {
     "agent": "example.module.agent",
-    "provider": "TitanAgents",
+    "provider": "TitanEchoAssist",
     "system_supervisor": "TitanZero",
     "supports": [
       "text",

--- a/Modules/ExampleModule/PWA/README.md
+++ b/Modules/ExampleModule/PWA/README.md
@@ -6,7 +6,7 @@ Minimum PWA requirements:
 
 - authenticated tenant context
 - module permission checks
-- chat endpoint bound to TitanAgents
+- chat endpoint bound to TitanEchoAssist
 - system-intent handoff to TitanZero
 - confirmation UI for write actions
 - citation panel for knowledge-backed answers

--- a/Modules/ExampleModule/README.md
+++ b/Modules/ExampleModule/README.md
@@ -11,7 +11,7 @@ This module follows the Titan AI-native module pattern:
 - top half: quick cards, widgets, module AI chatbot, shortcuts, settings
 - bottom half: one tabbed table card for all module tables
 - PWA/channel/voice control through the same agent and action map
-- TitanZero supervises system AI; TitanAgents runs the trained module agent; TitanCore provides AI infrastructure
+- TitanZero supervises system AI; TitanEchoAssist runs the trained module agent; TitanCore provides AI infrastructure
 
 See:
 

--- a/Modules/ExampleModule/module.json
+++ b/Modules/ExampleModule/module.json
@@ -11,7 +11,7 @@
   ],
   "requires": [
     "TitanCore",
-    "TitanAgents"
+    "TitanEchoAssist"
   ],
   "optional_requires": [
     "TitanZero",

--- a/Modules/TitanCore/Config/titan_agents.php
+++ b/Modules/TitanCore/Config/titan_agents.php
@@ -3,7 +3,7 @@
 return [
     // Pass 2 defaults.
     // TitanZero uses `kb_general_cleaning` for general reasoning.
-    // TitanAgents are topic-Configureed via their own KB collection keys.
+    // TitanEchoAssist agents are topic-configured via their own KB collection keys.
 
     'general_collection_key' => env('TITAN_ZERO_GENERAL_KB', 'kb_general_cleaning'),
 

--- a/Modules/TitanCore/Console/SyncTitanEchoAssistCommand.php
+++ b/Modules/TitanCore/Console/SyncTitanEchoAssistCommand.php
@@ -6,10 +6,10 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-class SyncTitanAgentsCommand extends Command
+class SyncTitanEchoAssistCommand extends Command
 {
     protected $signature = 'titan:sync-agents {--tenant_id=}';
-    protected $description = 'Sync default TitanAgents + KB collections from TitanCore config into the database.';
+    protected $description = 'Sync default TitanEchoAssist agents + KB collections from TitanCore config into the database.';
 
     public function handle(): int
     {

--- a/Modules/TitanCore/Providers/TitanCoreServiceProvider.php
+++ b/Modules/TitanCore/Providers/TitanCoreServiceProvider.php
@@ -23,7 +23,7 @@ use Modules\TitanCore\Console\Commands\ModulesUpgradeCommand;
 use Modules\TitanCore\Console\Commands\SyncTitanDocsKnowledgeCommand;
 use Modules\TitanCore\Console\Commands\ValidateManifestsCommand;
 use Modules\TitanCore\Console\Commands\VerifyManifestCommand;
-use Modules\TitanCore\Console\SyncTitanAgentsCommand;
+use Modules\TitanCore\Console\SyncTitanEchoAssistCommand;
 use Modules\TitanCore\Services\Providers\TitanAiProvider;
 use Modules\TitanCore\Services\TitanAiClient;
 use Modules\TitanCore\Services\TitanCoreModelGateway;
@@ -67,7 +67,7 @@ class TitanCoreServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 SyncTitanDocsKnowledgeCommand::class,
-                SyncTitanAgentsCommand::class,
+                SyncTitanEchoAssistCommand::class,
                 ModulesUpgradeCommand::class,
                 ModulesHealthCommand::class,
                 ModulesDoctorCommand::class,

--- a/Modules/TitanNexus/AI/Channels/channel.manifest.json
+++ b/Modules/TitanNexus/AI/Channels/channel.manifest.json
@@ -12,7 +12,7 @@
   ],
   "routing": {
     "system_ai": "TitanZero",
-    "module_ai": "TitanAgents",
+    "module_ai": "TitanEchoAssist",
     "handoff_rules": [
       "system_intents_to_zero",
       "module_intents_to_agent",

--- a/Modules/TitanNexus/AI/Control/README.md
+++ b/Modules/TitanNexus/AI/Control/README.md
@@ -5,14 +5,14 @@ This module is controllable through Filament chat, PWA chat, connected channels,
 ## Runtime ownership
 
 - **TitanZero** is the system AI supervisor: routing, governance, configuration, diagnostics, cross-module orchestration.
-- **TitanAgents** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
+- **TitanEchoAssist** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
 - **TitanCore** owns providers, embeddings, retrieval primitives, prompt registry, usage tracking, policies, and audit infrastructure.
 
 ## Command lifecycle
 
 1. User speaks or chats from Filament, PWA, or an external channel.
 2. TitanZero classifies whether the request is system-level or module-level.
-3. Module-level requests route to this module's TitanAgents agent.
+3. Module-level requests route to this module's TitanEchoAssist agent.
 4. The agent retrieves from `Knowledge/`, reads the module state, and selects an action.
 5. Write/destructive actions require confirmation unless explicitly marked safe.
 6. TitanCore logs usage, policy decisions, citations, and tool execution.

--- a/Modules/TitanNexus/AI/README.md
+++ b/Modules/TitanNexus/AI/README.md
@@ -1,3 +1,3 @@
 # AI Integration Layer
 
-Contracts that connect this module to TitanCore, TitanZero and TitanAgents without duplicating AI infrastructure.
+Contracts that connect this module to TitanCore, TitanZero and TitanEchoAssist without duplicating AI infrastructure.

--- a/Modules/TitanNexus/Agents/ModuleAgent/agent.manifest.json
+++ b/Modules/TitanNexus/Agents/ModuleAgent/agent.manifest.json
@@ -3,7 +3,7 @@
   "agent": "titan-nexus.agent",
   "display_name": "Titan Nexus Agent",
   "module": "titan-nexus",
-  "owner": "TitanAgents",
+  "owner": "TitanEchoAssist",
   "runtime": "TitanCore.ProviderRouter",
   "system_supervisor": "TitanZero",
   "answer_mode": "grounded_with_citations",

--- a/Modules/TitanNexus/Agents/ModuleAgent/policies/agent-policy.md
+++ b/Modules/TitanNexus/Agents/ModuleAgent/policies/agent-policy.md
@@ -1,3 +1,3 @@
 # Module Agent Policy
 
-The agent is trained/bound by TitanAgents, consumes TitanCore for AI runtime, and is supervised by TitanZero. It may only access current-company data.
+The agent is trained/bound by TitanEchoAssist, consumes TitanCore for AI runtime, and is supervised by TitanZero. It may only access current-company data.

--- a/Modules/TitanNexus/Agents/README.md
+++ b/Modules/TitanNexus/Agents/README.md
@@ -1,3 +1,3 @@
 # Module Agents
 
-TitanAgents owns module-specific trained agents. TitanCore supplies AI infrastructure. TitanZero supervises system AI, configuration, governance and diagnostics. The module owns domain files, tools, workflows and actions.
+TitanEchoAssist owns module-specific trained agents. TitanCore supplies AI infrastructure. TitanZero supervises system AI, configuration, governance and diagnostics. The module owns domain files, tools, workflows and actions.

--- a/Modules/TitanNexus/Config/module.php
+++ b/Modules/TitanNexus/Config/module.php
@@ -17,7 +17,7 @@ return [
     'ai' => [
         'core_runtime' => 'TitanCore',
         'system_supervisor' => 'TitanZero',
-        'agent_owner' => 'TitanAgents',
+        'agent_owner' => 'TitanEchoAssist',
         'agent_manifest' => base_path('Modules/TitanNexus/Agents/ModuleAgent/agent.manifest.json'),
         'indexing_manifest' => base_path('Modules/TitanNexus/AI/Indexing/indexing.manifest.json'),
     ],

--- a/Modules/TitanNexus/Docs/AI_CONTROL_AND_CHANNELS.md
+++ b/Modules/TitanNexus/Docs/AI_CONTROL_AND_CHANNELS.md
@@ -20,4 +20,4 @@ Read actions can execute after policy checks. Draft actions do not save until co
 
 ## Routing model
 
-TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanAgents handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.
+TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanEchoAssist handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.

--- a/Modules/TitanNexus/Docs/AI_NATIVE_MODULE_GUIDE.md
+++ b/Modules/TitanNexus/Docs/AI_NATIVE_MODULE_GUIDE.md
@@ -6,7 +6,7 @@ Each Titan module can ship domain knowledge and one or more module agents.
 |---|---|
 | TitanCore | provider routing, embeddings, vector search, memory, usage, policy middleware |
 | TitanZero | system AI, configuration, governance, diagnostics, escalation |
-| TitanAgents | module agent builder, training/binding, evals, deployment |
+| TitanEchoAssist | module agent builder, training/binding, evals, deployment |
 | Module | domain files, workflows, actions, tools, permissions |
 
-Lifecycle: add files to Knowledge, approve them in dataset-manifest, TitanCore indexes them, TitanAgents binds the agent, TitanZero monitors and configures.
+Lifecycle: add files to Knowledge, approve them in dataset-manifest, TitanCore indexes them, TitanEchoAssist binds the agent, TitanZero monitors and configures.

--- a/Modules/TitanNexus/Filament/PageManifest/module-page.json
+++ b/Modules/TitanNexus/Filament/PageManifest/module-page.json
@@ -23,7 +23,7 @@
   },
   "chat": {
     "agent": "titan_nexus.module.agent",
-    "provider": "TitanAgents",
+    "provider": "TitanEchoAssist",
     "system_supervisor": "TitanZero",
     "supports": [
       "text",

--- a/Modules/TitanNexus/PWA/README.md
+++ b/Modules/TitanNexus/PWA/README.md
@@ -6,7 +6,7 @@ Minimum PWA requirements:
 
 - authenticated tenant context
 - module permission checks
-- chat endpoint bound to TitanAgents
+- chat endpoint bound to TitanEchoAssist
 - system-intent handoff to TitanZero
 - confirmation UI for write actions
 - citation panel for knowledge-backed answers

--- a/Modules/TitanZero/Services/ZeroGateway.php
+++ b/Modules/TitanZero/Services/ZeroGateway.php
@@ -7,7 +7,7 @@ use Modules\TitanCore\Services\AgentRegistryService;
 use Modules\TitanCore\Services\KbCollectionService;
 use Modules\TitanCore\Services\KnowledgeSearchService;
 use Modules\TitanCore\Contracts\AI\ClientInterface;
-use Modules\TitanAgents\Services\AgentPlaybookService;
+use Modules\TitanEchoAssist\Services\AgentPlaybookService;
 
 /**
  * Titan Zero Gateway Service

--- a/Modules/ZeroPayModule/AI/Control/README.md
+++ b/Modules/ZeroPayModule/AI/Control/README.md
@@ -5,14 +5,14 @@ This module is controllable through Filament chat, PWA chat, connected channels,
 ## Runtime ownership
 
 - **TitanZero** is the system AI supervisor: routing, governance, configuration, diagnostics, cross-module orchestration.
-- **TitanAgents** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
+- **TitanEchoAssist** owns the module agent runtime: trained module agent, tools, knowledge binding, action execution, and module-specific conversations.
 - **TitanCore** owns providers, embeddings, retrieval primitives, prompt registry, usage tracking, policies, and audit infrastructure.
 
 ## Command lifecycle
 
 1. User speaks or chats from Filament, PWA, or an external channel.
 2. TitanZero classifies whether the request is system-level or module-level.
-3. Module-level requests route to this module's TitanAgents agent.
+3. Module-level requests route to this module's TitanEchoAssist agent.
 4. The agent retrieves from `Knowledge/`, reads the module state, and selects an action.
 5. Write/destructive actions require confirmation unless explicitly marked safe.
 6. TitanCore logs usage, policy decisions, citations, and tool execution.

--- a/Modules/ZeroPayModule/AI/README.md
+++ b/Modules/ZeroPayModule/AI/README.md
@@ -1,3 +1,3 @@
 # AI Integration Layer
 
-Contracts that connect this module to TitanCore, TitanZero and TitanAgents without duplicating AI infrastructure.
+Contracts that connect this module to TitanCore, TitanZero and TitanEchoAssist without duplicating AI infrastructure.

--- a/Modules/ZeroPayModule/Agents/ModuleAgent/agent.manifest.json
+++ b/Modules/ZeroPayModule/Agents/ModuleAgent/agent.manifest.json
@@ -6,7 +6,7 @@
   "name": "ZeroPay Payment Agent",
   "description": "Handles payment session queries, gateway status, and transaction lookups",
   "module": "zeropay-module",
-  "owner": "TitanAgents",
+  "owner": "TitanEchoAssist",
   "runtime": "TitanCore.ProviderRouter",
   "system_supervisor": "TitanZero",
   "answer_mode": "grounded_with_citations",

--- a/Modules/ZeroPayModule/Agents/ModuleAgent/policies/agent-policy.md
+++ b/Modules/ZeroPayModule/Agents/ModuleAgent/policies/agent-policy.md
@@ -1,3 +1,3 @@
 # Module Agent Policy
 
-The agent is trained/bound by TitanAgents, consumes TitanCore for AI runtime, and is supervised by TitanZero. It may only access current-company data.
+The agent is trained/bound by TitanEchoAssist, consumes TitanCore for AI runtime, and is supervised by TitanZero. It may only access current-company data.

--- a/Modules/ZeroPayModule/Docs/AI_CONTROL_AND_CHANNELS.md
+++ b/Modules/ZeroPayModule/Docs/AI_CONTROL_AND_CHANNELS.md
@@ -20,4 +20,4 @@ Read actions can execute after policy checks. Draft actions do not save until co
 
 ## Routing model
 
-TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanAgents handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.
+TitanZero handles system configuration, cross-module orchestration, diagnostics, and governance. TitanEchoAssist handles the module-trained AI and module tools. TitanCore handles providers, embeddings, vector search, memory, usage, policy, audit, and prompt registry.

--- a/Modules/ZeroPayModule/Docs/AI_NATIVE_MODULE_GUIDE.md
+++ b/Modules/ZeroPayModule/Docs/AI_NATIVE_MODULE_GUIDE.md
@@ -6,7 +6,7 @@ Each Titan module can ship domain knowledge and one or more module agents.
 |---|---|
 | TitanCore | provider routing, embeddings, vector search, memory, usage, policy middleware |
 | TitanZero | system AI, configuration, governance, diagnostics, escalation |
-| TitanAgents | module agent builder, training/binding, evals, deployment |
+| TitanEchoAssist | module agent builder, training/binding, evals, deployment |
 | Module | domain files, workflows, actions, tools, permissions |
 
-Lifecycle: add files to Knowledge, approve them in dataset-manifest, TitanCore indexes them, TitanAgents binds the agent, TitanZero monitors and configures.
+Lifecycle: add files to Knowledge, approve them in dataset-manifest, TitanCore indexes them, TitanEchoAssist binds the agent, TitanZero monitors and configures.

--- a/Modules/ZeroPayModule/Filament/PageManifest/module-page.json
+++ b/Modules/ZeroPayModule/Filament/PageManifest/module-page.json
@@ -23,7 +23,7 @@
   },
   "chat": {
     "agent": "zeropay.module.agent",
-    "provider": "TitanAgents",
+    "provider": "TitanEchoAssist",
     "system_supervisor": "TitanZero",
     "supports": [
       "text",

--- a/Modules/ZeroPayModule/PWA/README.md
+++ b/Modules/ZeroPayModule/PWA/README.md
@@ -6,7 +6,7 @@ Minimum PWA requirements:
 
 - authenticated tenant context
 - module permission checks
-- chat endpoint bound to TitanAgents
+- chat endpoint bound to TitanEchoAssist
 - system-intent handoff to TitanZero
 - confirmation UI for write actions
 - citation panel for knowledge-backed answers

--- a/Modules/ZeroPayModule/README.md
+++ b/Modules/ZeroPayModule/README.md
@@ -11,7 +11,7 @@ This module follows the Titan AI-native module pattern:
 - top half: quick cards, widgets, module AI chatbot, shortcuts, settings
 - bottom half: one tabbed table card for all module tables
 - PWA/channel/voice control through the same agent and action map
-- TitanZero supervises system AI; TitanAgents runs the trained module agent; TitanCore provides AI infrastructure
+- TitanZero supervises system AI; TitanEchoAssist runs the trained module agent; TitanCore provides AI infrastructure
 
 See:
 

--- a/Modules/ZeroPayModule/module.json
+++ b/Modules/ZeroPayModule/module.json
@@ -11,7 +11,7 @@
   ],
   "requires": [
     "TitanCore",
-    "TitanAgents"
+    "TitanEchoAssist"
   ],
   "optional_requires": [
     "TitanZero",


### PR DESCRIPTION
- module.json requires: Accountings, EInvoice, ExampleModule, ZeroPayModule
- SyncTitanAgentsCommand renamed to SyncTitanEchoAssistCommand (file + class + provider import)
- ZeroGateway.php namespace updated from Modules\TitanAgents to Modules\TitanEchoAssist
- titan_agents.php comment updated
- All agent.manifest.json, channel.manifest.json, module-page.json, policy.md, README.md, AI docs, and Config/module.php files updated across Accountings, BookingModule, EInvoice, ExampleModule, TitanNexus, ZeroPayModule modules
- GitHub issue #533 updated to reflect TitanAgents resolution